### PR TITLE
style: chapter Markdown image styling

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -8,3 +8,11 @@
   width: 100%;
   height: 100%;
 }
+
+/* Images embedded in chapter Markdown (optional — cards without images are unaffected) */
+.prose img {
+  width: 100%;
+  border-radius: 0.5rem;
+  margin-top: 0.75rem;
+  display: block;
+}


### PR DESCRIPTION
## Summary

- Adds `.prose img` CSS rules to `app/src/index.css` so images embedded in chapter Markdown cards render correctly inside the glassmorphism narrative cards.
- Images are displayed full-width (`width: 100%`), with rounded corners (`border-radius: 0.5rem`), a small top margin, and `display: block` to eliminate inline spacing artifacts.
- Cards without images are completely unaffected — the selector only matches `<img>` elements inside `.prose` containers.

## Test plan

- [ ] Verify `npm test` and `npm run lint` pass (both confirmed clean before opening this PR)
- [ ] Check staging preview once `deploy-staging.yaml` posts the URL
- [ ] Confirm a chapter card that contains an image (e.g. via Markdown `![alt](url)`) renders full-width with rounded corners
- [ ] Confirm chapter cards without images look unchanged

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)