### PR TITLE
fix: update chapter 2 (Gateway) map coordinates

### DIFF
--- a/app/chapters/02-gateway/content.md
+++ b/app/chapters/02-gateway/content.md
@@ -6,14 +6,14 @@ subtitle: 'Entry Point: S Jackson St'
 icon: Navigation
 color: '#ea580c'
 mapState:
-  longitude: -122.3067
-  latitude: 47.6037
+  longitude: -122.306348
+  latitude: 47.597486
   zoom: 16.5
   pitch: 50
   bearing: 10
 marker:
-  longitude: -122.3067
-  latitude: 47.6037
+  longitude: -122.306348
+  latitude: 47.597486
 ---
 
 S Jackson Street is the commercial heart of the Central District. Today, 20th Ave S funnels cut-through car traffic at speed through a walkable neighborhood.


### PR DESCRIPTION
Updates the chapter 2 (20th Ave S Gateway) `mapState` and `marker` coordinates to the more precise location:

- **Latitude:** 47.597486°N
- **Longitude:** 122.306348°W

Both `mapState` and `marker` entries in `app/chapters/02-gateway/content.md` are updated from the previous rounded values (`47.6037, -122.3067`).