### PR TITLE
content: mission lede now says the station opened (past tense)

### DIFF
--- a/app/chapters/01-mission/content.md
+++ b/app/chapters/01-mission/content.md
@@ -15,4 +15,4 @@ marker:
   latitude: 47.590320
 ---
 
-The **Judkins Park Light Rail Station** opens March 28, 2026 — bringing thousands of daily riders to one of Seattle's most vibrant and diverse neighborhoods. **The streets around it were built for cars. This is a proposal to change that.**
+The **Judkins Park Light Rail Station** opened March 28, 2026 — bringing thousands of daily riders to one of Seattle's most vibrant and diverse neighborhoods. **The streets around it were built for cars. This is a proposal to change that.**


### PR DESCRIPTION
`CONTENT` — **COPY DESK**

# The station is open — so is the tense

> _The Judkins Park light-rail station opened on schedule; the mission chapter's opening line now says so, swapping a future promise for a present-day fact._

> [!NOTE]
> **content** · copy · risk: low

March 28, 2026 came and went, and trains now run through Judkins Park. The site's first words still greeted readers in the future tense — "the station **opens** March 28, 2026" — a small anachronism that quietly dated the whole pitch. This change moves the lede into the present: the station **opened**, the riders are arriving, and the case for streets built around people instead of cars is no longer a forecast but a response to what's already here.

## What changed
- `app/chapters/01-mission/content.md` — the mission hook shifts from "opens March 28, 2026" to "opened March 28, 2026".
- One word, one tense; the argument and the date are untouched.

> _"The streets around it were built for cars. This is a proposal to change that."_ — unchanged, and now landing on a station that exists.

## How it flows
No flow change — this is a single content-copy edit to the mission chapter's body text.

## Verification
- Confirmed via `gh pr diff 37`: a one-line change in `01-mission/content.md`, "opens" → "opened", with the surrounding paragraph and frontmatter (marker coordinates, chapter metadata) untouched.

## Risk & rollout
- Negligible. Pure prose, no code, no schema or frontmatter touched; revert is a one-word flip if needed.
